### PR TITLE
WIP - Begin to refactor so that activities are stored on visits

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -3,6 +3,6 @@ class VisitsController < ApplicationController
     @visits = Visit
     @visits = @visits.where(user_id: params[:user_id]) if params[:user_id]
     @visits = @visits.where(school_id: params[:school_id]) if params[:school_id]
-    @visits = @visits.order("id desc").page params[:page]
+    @visits = @visits.order("created_at desc").page params[:page]
   end
 end

--- a/app/helpers/visits_helper.rb
+++ b/app/helpers/visits_helper.rb
@@ -1,2 +1,0 @@
-module VisitsHelper
-end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity
   include ActiveModel::Attributes
   attr_accessor :school_id, :name
 
-  attribute :timestamp, Timestamp::Type.new, precision: 6
+  attribute :timestamp, Timestamp::Type.new
 
   def self.log(user, school_id, name, time)
     activity = new(school_id: school_id, name: name, timestamp: time)
@@ -15,6 +15,10 @@ class Activity
     calc_activity_type(name)
   end
 
+  def <=>(other)
+    other.timestamp <=> timestamp
+  end
+
   def to_h
     {
       school_id: school_id,
@@ -23,8 +27,16 @@ class Activity
     }
   end
 
+  def inspect
+    "#<#{self.class.name} #{to_h}>"
+  end
+
   def eql?(other)
-    to_h.values.map(&:to_s) == other.to_h.values.map(&:to_s)
+    self.==(other)
+  end
+
+  def ==(other)
+    to_h == other.to_h
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity
   include ActiveModel::Attributes
   attr_accessor :school_id, :name
 
-  attribute :timestamp, :datetime
+  attribute :timestamp, Timestamp::Type.new, precision: 6
 
   def self.log(user, school_id, name, time)
     activity = new(school_id: school_id, name: name, timestamp: time)
@@ -21,6 +21,10 @@ class Activity
       name: name,
       timestamp: timestamp
     }
+  end
+
+  def eql?(other)
+    to_h.values.map(&:to_s) == other.to_h.values.map(&:to_s)
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,26 +1,26 @@
-class Activity < ApplicationRecord
-  belongs_to :user
-  belongs_to :visit, optional: true # optional, because activity is created first, and exists for a moment w/o a visit
+class Activity
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  attr_accessor :school_id, :name
+
+  attribute :timestamp, :datetime
 
   def self.log(user, school_id, name, time)
-    activity = Activity.create!(user: user, school_id: school_id, name: name, created_at: time)
-    user.last_activity = activity
-
-    if user.last_visit&.includes?(activity)
-      user.last_visit.append(activity)
-    else
-      user.last_visit = Visit.start(user, activity)
-    end
-    user.save
-
-    activity.visit = user.last_visit
-    activity.save!
+    activity = new(school_id: school_id, name: name, timestamp: time)
+    user.last_visit.start_or_append(activity)
     activity
   end
 
-  def name=(value)
-    self[:name] = value
-    self.activity_type = calc_activity_type(value)
+  def activity_type
+    calc_activity_type(name)
+  end
+
+  def to_h
+    {
+      school_id: school_id,
+      name: name,
+      timestamp: timestamp
+    }
   end
 
   private

--- a/app/models/activity_collection.rb
+++ b/app/models/activity_collection.rb
@@ -30,16 +30,14 @@ class ActivityCollection
 
   class Type < ActiveModel::Type::Value
     def changed?(old_value, new_value, _new_value_before_type_cast)
-      byebug
       old_value != new_value
     end
 
     def changed_in_place?(raw_old_value, new_value)
-      byebug
       deserialize(raw_old_value) != new_value
     end
 
-    def cast(value)
+    def cast_value(value)
       return ActivityCollection.new if value.nil? || value.blank?
       return value if value.is_a?(ActivityCollection)
       return ActivityCollection.new(value) if value.respond_to?(:each)
@@ -47,10 +45,11 @@ class ActivityCollection
       JSON.parse(value, symbolize_names: true).map do |activity_attributes|
         activity_collection << Activity.new(activity_attributes)
       end
+      activity_collection
     end
 
     def serialize(value)
-      return "[]" if value.blank?
+      return [] if value.blank?
       JSON.dump(value.map(&:to_h))
     end
   end

--- a/app/models/activity_collection.rb
+++ b/app/models/activity_collection.rb
@@ -1,7 +1,7 @@
 # A sequence of activities ordered by timestamp
 class ActivityCollection
   attr_accessor :activities
-  delegate :map, :each, to: :activities
+  delegate :include?, :map, :each, :length, :[], to: :activities
 
   def initialize(activities = [])
     self.activities = activities
@@ -10,22 +10,25 @@ class ActivityCollection
   def least_recent
     activities.last
   end
+  alias_method :first, :least_recent
 
   def most_recent
     activities.first
   end
+  alias_method :last, :most_recent
 
   def <<(activity)
     splice(activity.respond_to?(:timestamp) ? activity : Activity.new(activity))
   end
 
   private def splice(activity)
-    splice_point = activities.index { |other| other.timestamp > activity.timestamp }
-    if splice_point
-      activities.insert(splice_point, activity)
-    else
-      activities.unshift(activity)
-    end
+    activities.unshift(activity)
+    activities.sort!
+    self
+  end
+
+  def to_s
+    to_h.to_s
   end
 
   class Type < ActiveModel::Type::Value

--- a/app/models/activity_collection.rb
+++ b/app/models/activity_collection.rb
@@ -1,0 +1,57 @@
+# A sequence of activities ordered by timestamp
+class ActivityCollection
+  attr_accessor :activities
+  delegate :map, :each, to: :activities
+
+  def initialize(activities = [])
+    self.activities = activities
+  end
+
+  def least_recent
+    activities.last
+  end
+
+  def most_recent
+    activities.first
+  end
+
+  def <<(activity)
+    splice(activity.respond_to?(:timestamp) ? activity : Activity.new(activity))
+  end
+
+  private def splice(activity)
+    splice_point = activities.index { |other| other.timestamp > activity.timestamp }
+    if splice_point
+      activities.insert(splice_point, activity)
+    else
+      activities.unshift(activity)
+    end
+  end
+
+  class Type < ActiveModel::Type::Value
+    def changed?(old_value, new_value, _new_value_before_type_cast)
+      byebug
+      old_value != new_value
+    end
+
+    def changed_in_place?(raw_old_value, new_value)
+      byebug
+      deserialize(raw_old_value) != new_value
+    end
+
+    def cast(value)
+      return ActivityCollection.new if value.nil? || value.blank?
+      return value if value.is_a?(ActivityCollection)
+      return ActivityCollection.new(value) if value.respond_to?(:each)
+      activity_collection = ActivityCollection.new
+      JSON.parse(value, symbolize_names: true).map do |activity_attributes|
+        activity_collection << Activity.new(activity_attributes)
+      end
+    end
+
+    def serialize(value)
+      return "[]" if value.blank?
+      JSON.dump(value.map(&:to_h))
+    end
+  end
+end

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -1,0 +1,12 @@
+class Timestamp < DateTime
+  class Type < ActiveModel::Type::DateTime
+    def cast_value(value)
+      value = value.change(usec: 0) if(value.respond_to?(:change))
+      super(value)
+    end
+
+    def serialize(value)
+      super(value)
+    end
+  end
+end

--- a/app/models/timestamp.rb
+++ b/app/models/timestamp.rb
@@ -2,6 +2,7 @@ class Timestamp < DateTime
   class Type < ActiveModel::Type::DateTime
     def cast_value(value)
       value = value.change(usec: 0) if(value.respond_to?(:change))
+      value = value.to_datetime if value.respond_to?(:to_datetime)
       super(value)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :visits
   belongs_to :last_visit, class_name: "Visit", optional: true
-  has_many :activities
-  belongs_to :last_activity, class_name: "Activity", optional: true
+
+  def last_visit
+    super || Visit.new(user: self, activities: [])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
   has_many :visits
-  belongs_to :last_visit, class_name: "Visit", optional: true
 
   def last_visit
-    super || Visit.new(user: self, activities: [])
+    @last_visit ||= (self.visits.order(created_at: :desc).limit(1).first || Visit.new(user: self, activities: []))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@ class User < ApplicationRecord
   has_many :visits
 
   def last_visit
-    @last_visit ||= (self.visits.order(created_at: :desc).limit(1).first || Visit.new(user: self, activities: []))
+    (self.visits.order(created_at: :desc).limit(1).first || Visit.new(user: self, activities: []))
   end
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -36,6 +36,7 @@ class Visit < ApplicationRecord
   end
 
   def start_or_append(activity)
+    byebug
     return append(activity) if covers?(activity)
     Visit.start(user, activity)
   end

--- a/app/views/visits/index.html.erb
+++ b/app/views/visits/index.html.erb
@@ -14,7 +14,7 @@
     <tr>
       <td><%= link_to visit.user_id, user_visits_path(user_id: visit.user_id) %></td>
       <td><%= link_to visit.school_id, school_visits_path(school_id: visit.school_id) %></td>
-      <td><%= distance_of_time_in_words Time.now, visit.seconds.seconds.from_now %></td>
+      <td><%= distance_of_time_in_words Time.zone.now, visit.seconds.seconds.from_now %></td>
       <td><%= time_ago_in_words visit.start_at %> ago</td>
       <td>
         <% visit.activities.each do |activity| %>

--- a/config/initializers/time.rb
+++ b/config/initializers/time.rb
@@ -1,0 +1,1 @@
+Time.zone = "UTC"

--- a/db/migrate/20190917183105_add_activities_to_visits.rb
+++ b/db/migrate/20190917183105_add_activities_to_visits.rb
@@ -1,0 +1,8 @@
+class AddActivitiesToVisits < ActiveRecord::Migration[6.0]
+  def change
+    add_column :visits, :activities, :jsonb, null: false, default: []
+
+    add_timestamps :visits, null: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_163826) do
+ActiveRecord::Schema.define(version: 2019_09_17_183105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,10 @@ ActiveRecord::Schema.define(version: 2019_09_16_163826) do
     t.integer "seconds"
     t.integer "start_activity_id"
     t.integer "stop_activity_id"
+    t.jsonb "activities", default: [], null: false
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
     t.index ["user_id"], name: "index_visits_on_user_id"
   end
+
 end

--- a/spec/controllers/api/sparklines_controller_spec.rb
+++ b/spec/controllers/api/sparklines_controller_spec.rb
@@ -5,21 +5,13 @@ RSpec.describe Api::SparklinesController, type: :controller do
   let(:user1) { FactoryBot.create(:user) }
   let(:user2) { FactoryBot.create(:user) }
 
-  def create_visit!(args)
-    args[:school_id] = school_id
-    args[:seconds] = args[:seconds].to_i
-    args[:start_activity] ||= Activity.create! school_id: school_id, user: args[:user], name: "bob"
-    args[:stop_activity] ||= args[:start_activity]
-    Visit.create! args
-  end
-
   describe "#index" do
     it "should return several sparklines" do
       Time.zone = "UTC"
 
       today = Time.zone.today
 
-      create_visit! user: user1, start_at: today - 1.day + 1.hour, seconds: 30.minutes
+      Visit.create! user: user1, activities: [Activity.new(timestamp: today - 1.day + 1.hour)], seconds: 30.minutes.to_i
 
       get :index, params: {school_id: school_id,
                            ids: [user1.id, -1],}

--- a/spec/controllers/api/sparklines_controller_spec.rb
+++ b/spec/controllers/api/sparklines_controller_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Api::SparklinesController, type: :controller do
 
   describe "#index" do
     it "should return several sparklines" do
-      Time.zone = "UTC"
-
       today = Time.zone.today
 
       Visit.create! user: user1, activities: [Activity.new(timestamp: today - 1.day + 1.hour)], seconds: 30.minutes.to_i

--- a/spec/controllers/logs_controller_spec.rb
+++ b/spec/controllers/logs_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe LogsController, type: :controller do
       expect(response).to be_successful
 
       visits = Visit.all
-      byebug
       expect(visits.length).to eq 2
       expect(visits[0].user_id).to eq(55)
       expect(visits[0].activities.most_recent.name).to eq("GET /s/973/dashboard")

--- a/spec/controllers/logs_controller_spec.rb
+++ b/spec/controllers/logs_controller_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe LogsController, type: :controller do
     it "should record activity" do
       http_login
 
-      expect(Activity.count).to eq 0
-
       log = <<~LOG
         374 <190>1 2019-09-13T17:31:38.949095+00:00 host app worker.3 - I, [2019-09-13T17:31:38.948722 #4]  INFO -- : [ActiveJob] [DelayedPaperclip::ProcessJob] [eed7b9b4-88df-4552-aa0c-d16514ee46b4] Command :: convert -auto-orient '/tmp/cb803fb775c7cc0961b14131ec78bf5220190913-4-yrxt9e.jpg[0]' -auto-orient -resize \"3264x3264\" '/tmp/32ad8484817257547aadd8362e07625320190913-4-fjf26m'
         377 <190>1 2019-09-13T17:32:44.283026+00:00 host app web.2 - I, [2019-09-13T17:32:40.048706 #36]  INFO -- : [2437a15b-3e78-4490-9452-2462011d3484] {\"method\":\"GET\",\"path\":\"/s/973/dashboard\",\"format\":\"html\",\"controller\":\"DashboardController\",\"action\":\"show\",\"status\":200,\"duration\":370.1,\"view\":88.66,\"db\":257.4,\"user_id\":\"55\",\"school_id\":973,\"params\":{\"school_id\":\"973\"}}
@@ -24,14 +22,15 @@ RSpec.describe LogsController, type: :controller do
 
       expect(response).to be_successful
 
-      activities = Activity.all
-      expect(activities.length).to eq 2
-      expect(activities[0].user_id).to eq(55)
-      expect(activities[0].name).to eq("GET /s/973/dashboard")
-      expect(activities[0].school_id).to eq(973)
-      expect(activities[1].user_id).to eq(66)
-      expect(activities[1].name).to eq("GET /s/369/classrooms/2313/events.json")
-      expect(activities[1].school_id).to eq(369)
+      visits = Visit.all
+      byebug
+      expect(visits.length).to eq 2
+      expect(visits[0].user_id).to eq(55)
+      expect(visits[0].activities.most_recent.name).to eq("GET /s/973/dashboard")
+      expect(visits[0].school_id).to eq(973)
+      expect(visits[1].user_id).to eq(66)
+      expect(visits[1].activities.most_recent.name).to eq("GET /s/369/classrooms/2313/events.json")
+      expect(visits[1].school_id).to eq(369)
     end
   end
 end

--- a/spec/models/activity_collection_spec.rb
+++ b/spec/models/activity_collection_spec.rb
@@ -1,0 +1,7 @@
+describe ActivityCollection do
+  it "maintains ordering so the most recent"
+  describe "#<<" do
+    it "Casts hashes to Activity objects"
+    it "Maintains the ordering by timestamp with the most recent at the start"
+  end
+end

--- a/spec/models/activity_collection_spec.rb
+++ b/spec/models/activity_collection_spec.rb
@@ -1,7 +1,57 @@
+require 'rails_helper'
+
 describe ActivityCollection do
-  it "maintains ordering so the most recent"
+  subject(:activity_collection) { ActivityCollection.new }
+  let(:first) { Activity.new(timestamp: 4.minutes.ago) }
+  let(:second) { Activity.new(timestamp: 3.minutes.ago) }
+  let(:third) { Activity.new(timestamp: 2.minutes.ago) }
+  let(:fourth) { Activity.new(timestamp: 1.minutes.ago) }
+  before do
+    [third, fourth, first, second].each do |activity|
+      activity_collection << activity
+    end
+  end
+
+  describe "#most_recent" do
+    subject(:most_recent) { activity_collection.most_recent }
+    it { is_expected.to eql(fourth) }
+  end
+
+  describe "#first" do
+    subject(:result) { activity_collection.first }
+    it { is_expected.to eql(activity_collection.least_recent) }
+  end
+
+  describe "#last" do
+    subject(:last) { activity_collection.last }
+    it { is_expected.to eql(activity_collection.most_recent) }
+  end
+
+  describe "#least_recent" do
+    subject(:least_recent) { activity_collection.least_recent }
+    it { is_expected.to eql(first) }
+  end
+
   describe "#<<" do
-    it "Casts hashes to Activity objects"
-    it "Maintains the ordering by timestamp with the most recent at the start"
+    it "Casts hashes to Activity objects" do
+      activity_collection << { timestamp: 1.minute.ago }
+      expect(activity_collection[0]).to be_kind_of(Activity)
+    end
+
+    it "Maintains the ordering by timestamp with the most recent at the start" do
+      activity_collection = ActivityCollection.new
+
+      activity_collection << second
+      activity_collection << first
+      activity_collection << third
+      activity_collection << fourth
+
+      aggregate_failures do
+        expect(activity_collection[3]).to eql(first)
+        expect(activity_collection[2]).to eql(second)
+        expect(activity_collection[1]).to eql(third)
+        expect(activity_collection[0]).to eql(fourth)
+      end
+    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Activity, type: :model do
   describe ".log" do
     let(:school_id) { 5 }
     let(:u) { FactoryBot.create(:user) }
-    let(:time) { Time.zone.new(2019, 10, 1, 5, 6, 7) }
+    let(:time) { Time.new(2019, 10, 1, 5, 6, 7) }
 
     it "creates an activitiy within a visit associated to the school and user" do
       activity = (Activity.log u, school_id, "Yelling at the kids", time)
@@ -29,8 +29,8 @@ RSpec.describe Activity, type: :model do
       visit = u.last_visit
 
       expect(visit.seconds).to eq(30)
-      expect(visit.start_activity).to eq(actvity)
-      expect(visit.stop_activity).to eq(actvity)
+      expect(visit.start_activity).to eq(activity)
+      expect(visit.stop_activity).to eq(activity)
     end
 
     it "should add to it as long as interval < visit::INTERVAL" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Activity, type: :model do
   describe ".log" do
     let(:school_id) { 5 }
     let(:u) { FactoryBot.create(:user) }
-    let(:time) { Time.new(2019, 10, 1, 5, 6, 7) }
+    let(:time) { Time.zone.new(2019, 10, 1, 5, 6, 7) }
 
     it "creates an activitiy within a visit associated to the school and user" do
       activity = (Activity.log u, school_id, "Yelling at the kids", time)
@@ -34,7 +34,7 @@ RSpec.describe Activity, type: :model do
     end
 
     it "should add to it as long as interval < visit::INTERVAL" do
-      start = now = Time.now - 1.day
+      start = now = Time.zone.now - 1.day
 
       one = Activity.log u, school_id, "one", now
       visit = u.reload.last_visit
@@ -74,9 +74,8 @@ RSpec.describe Activity, type: :model do
     end
 
     it "should create a new visit if interval > visit::INTERVAL" do
-      now = Time.now - 1.day
+      now = Time.zone.now - 1.day
 
-      # allow(Time).to receive(:now).and_return(now)
       one = Activity.log u, school_id, "one", now
       visit = u.reload.last_visit
       aggregate_failures do
@@ -88,7 +87,6 @@ RSpec.describe Activity, type: :model do
       end
 
       later = now + Visit::INTERVAL + 31.second
-      # allow(Time).to receive(:now).and_return(later)
       two = Activity.log u, school_id, "two", later
 
       visit = u.reload.last_visit

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Visit, type: :model do
   def create_visit!(args)
     args[:school_id] = school_id
     args[:seconds] = args[:seconds].to_i
-    args[:start_activity] ||= Activity.create! school_id: school_id, user: args[:user], name: "bob"
-    args[:stop_activity] ||= args[:start_activity]
+    start_at = args.delete(:start_at)
+    args[:activities] = [Activity.new(timestamp: start_at)] if start_at
     Visit.create! args
   end
 

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -33,4 +33,37 @@ RSpec.describe Visit, type: :model do
         })
     end
   end
+
+  describe "#append(activity)" do
+    it "Adds to the activities collection" do
+      visit = Visit.new(user: FactoryBot.create(:user))
+      activity = Activity.new(timestamp: Time.zone.now)
+      visit.append(activity)
+
+      aggregate_failures do
+        expect(visit.activities.length).to eql(1)
+        expect(visit.activities).to include(activity)
+        expect(visit.start_activity).to eql(activity)
+        expect(visit.stop_activity).to eql(activity)
+        expect(visit.seconds).to eql(Visit::DEFAULT_DURATION)
+      end
+    end
+
+    it "Pushes out the seconds" do
+      visit = Visit.new(user: FactoryBot.create(:user))
+      first = Activity.new(timestamp: 30.seconds.ago)
+      visit.append(first)
+      second = Activity.new(timestamp: 0.seconds.ago)
+      visit.append(second)
+
+      aggregate_failures do
+        expect(visit.activities.length).to eql(2)
+        expect(visit.activities).to include(first)
+        expect(visit.activities).to include(second)
+        expect(visit.start_activity).to eql(first)
+        expect(visit.stop_activity).to eql(second)
+        expect(visit.seconds).to eql(60)
+      end
+    end
+  end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe Visit, type: :model do
 
   describe "sparkline_by_user" do
     it "should return minutes per day" do
-      Time.zone = "UTC"
-
       today = Time.zone.today
 
       create_visit! user: user1, start_at: today - 1.day + 1.hour, seconds: 30.minutes


### PR DESCRIPTION
After a bit more discussion with Andrew, we realized that we could
probably both save a pile of database space _and_ simplify the code base
quite a bit if we shift activities to a serialized field on the visits
table.

We never retrieve activities except as part of a visit, plus this allows
us the opportunity to work with the Rails 5/6 Attributes API which is
a pretty powerful way to work with structure data in the database in a
domain-driven manner.

This is a chainsaw refactor, so I don't expect it to land, but I would
like to talk through what I learned  when spiking it out, and how that may
(or may not) play into how we build out this service going forward.