### PR TITLE
Begin removing user_id from activities [sh24669]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
 end
 
 group :test do
+ gem "shoulda-matchers"
   # Adds support for Capybara system testing and selenium driver
   # gem 'capybara', '>= 2.15'
   # gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     snaky_hash (2.0.0)
       hashie
       version_gem (~> 1.1)
@@ -318,6 +320,7 @@ DEPENDENCIES
   rollbar
   rspec-rails (~> 4.0)
   sass-rails (~> 5)
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   web-console (>= 3.3.0)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,9 +1,12 @@
 class Activity < ApplicationRecord
-  belongs_to :user
+  self.ignored_columns = [:user_id]
   belongs_to :visit, optional: true # optional, because activity is created first, and exists for a moment w/o a visit
+  delegate :user, to: :visit, allow_nil: true
+  delegate :id, to: :user, prefix: true
+
 
   def self.log(user, school_id, name, time)
-    activity = Activity.create!(user: user, school_id: school_id, name: name, created_at: time)
+    activity = Activity.create!(school_id: school_id, name: name, created_at: time)
     user.last_activity = activity
 
     if user.last_visit&.includes?(activity)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,9 +1,8 @@
 class Activity < ApplicationRecord
   self.ignored_columns = [:user_id]
   belongs_to :visit, optional: true # optional, because activity is created first, and exists for a moment w/o a visit
-  delegate :user, to: :visit, allow_nil: true
-  delegate :id, to: :user, prefix: true
-
+  has_one :user, through: :visit
+  delegate :id, to: :user, prefix: true, allow_nil: true
 
   def self.log(user, school_id, name, time)
     activity = Activity.create!(school_id: school_id, name: name, created_at: time)

--- a/db/migrate/20230928224234_drop_activities_user_index.rb
+++ b/db/migrate/20230928224234_drop_activities_user_index.rb
@@ -1,0 +1,6 @@
+class DropActivitiesUserIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :activities, :user_id
+    change_column :activities, :user_id, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,27 +2,26 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_070730) do
+ActiveRecord::Schema.define(version: 2023_09_28_224234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.integer "school_id", null: false
     t.integer "visit_id"
     t.string "name", limit: 255, null: false
     t.string "activity_type", null: false
     t.datetime "created_at"
-    t.index ["user_id"], name: "index_activities_on_user_id"
     t.index ["visit_id"], name: "index_activities_on_visit_id"
   end
 

--- a/spec/controllers/api/sparklines_controller_spec.rb
+++ b/spec/controllers/api/sparklines_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::SparklinesController, type: :controller do
   def create_visit!(args)
     args[:school_id] = school_id
     args[:seconds] = args[:seconds].to_i
-    args[:start_activity] ||= Activity.create! school_id: school_id, user: args[:user], name: "bob"
+    args[:start_activity] ||= Activity.create! school_id: school_id, name: "bob"
     args[:stop_activity] ||= args[:start_activity]
     Visit.create! args
   end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Activity, type: :model do
+  it { is_expected.to belong_to(:visit).optional }
+  it { is_expected.to have_one(:user).through(:visit) }
+  it { is_expected.to delegate_method(:id).to(:user).with_prefix.allow_nil }
+
   describe ".log" do
     let(:school_id) { 5 }
     let(:u) { FactoryBot.create(:user) }

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Visit, type: :model do
   def create_visit!(args)
     args[:school_id] = school_id
     args[:seconds] = args[:seconds].to_i
-    args[:start_activity] ||= Activity.create! school_id: school_id, user: args[:user], name: "bob"
+    args[:start_activity] ||= Activity.create! school_id: school_id, name: "bob"
     args[:stop_activity] ||= args[:start_activity]
     Visit.create! args
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,3 +59,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
For some reason, we decided not only do we want to store the user id in both the visits and the activities table; we *also* want to index the user id in both places.

This results in... well; a lot of wasted space because we store the user_id twice.

Dumping this index should give us back 50GB+ of data; and dumping the *value* will probably save us 25GB+.

After which, I think we can safely drop WhoWasHere to a S1 database; especially if we add automatically delete old records on a quarterlyish basis.