### PR TITLE
Add services to Docker Compose [sh31727]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgresql:
+    image: "postgres:14"
+    container_name: "postgresql"
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - '5432:5432'
+    expose:
+      - '5432'
+    volumes:
+      - 'postgresql-data:/var/lib/postgresql/data'
+volumes:
+  postgresql-data:


### PR DESCRIPTION
https://app.shortcut.com/transparentclassroom/story/31727

In order to run the project, we need Postgresql. For those of us who do not run postgresql on our native os; it's nice to have a docker compose file to rely on.